### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
 
+compiler:
+  - clang
+  - gcc
+
 script:
   - cd build/x86_linux
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ compiler:
 script:
   - cd build/x86_linux
   - make
+  - make RELEASE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+
+script:
+  - cd build/x86_linux
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ language: c
 compiler:
   - clang
   - gcc
+  
+env:
+ - $comp: all
+ - $comp: RELEASE
 
 script:
   - cd build/x86_linux
-  - make
-  - make RELEASE
+  - make $comp
+  - make $comp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 360tools 
+# 360tools  [![Travis Build Status](https://travis-ci.org/Samsung/360tools.svg?branch=master)](https://travis-ci.org/Samsung/360tools)
 
 	Projection and quality evaluation tools for VR video compression exploration experiments
 


### PR DESCRIPTION
Add Travis CI to 360tools. The Linux Makefile is tested with both GCC and Clang compilers, with build targets `all` and `RELEASE`. Here's the latest run: https://travis-ci.com/EwoutH/360tools

Also adds a Build Status badge to the Readme.

Travis only needs to be activated on https://travis-ci.org/Samsung/360tools or on https://github.com/marketplace/travis-ci