### PR TITLE
Add automatic Windows builds with AppVeyor CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 360tools 
+# 360tools [![AppVeyor Build Status](https://ci.appveyor.com/project/EwoutH/360tools/branch/master?svg=true)](https://ci.appveyor.com/project/EwoutH/360tools)
 
 	Projection and quality evaluation tools for VR video compression exploration experiments
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Building
 
-Checkout the source for 360 Tools
+Checkout the source for 360 Tools. Automatic Windows x86-64 builds and libaries can be found on [AppVeyor](https://ci.appveyor.com/project/Samsung/360tools) under the Artifacts tab.
 
 	+ Windows
 	In 360tools/build/x86_windows/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 360tools [![AppVeyor Build Status](https://ci.appveyor.com/project/Samsung/360tools/branch/master?svg=true)](https://ci.appveyor.com/project/Samsung/360tools)
+# 360tools [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Samsung/360tools?branch=master&svg=true)](https://ci.appveyor.com/project/Samsung/360tools)
 
 	Projection and quality evaluation tools for VR video compression exploration experiments
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 360tools [![AppVeyor Build Status](https://ci.appveyor.com/project/EwoutH/360tools/branch/master?svg=true)](https://ci.appveyor.com/project/EwoutH/360tools)
+# 360tools [![AppVeyor Build Status](https://ci.appveyor.com/project/Samsung/360tools/branch/master?svg=true)](https://ci.appveyor.com/project/Samsung/360tools)
 
 	Projection and quality evaluation tools for VR video compression exploration experiments
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,5 @@ build_script:
  - msbuild c:\projects\360tools\build\x86_windows\%target%
  
 artifacts:
- - path: \**\360tools.exe
- - path: \**\360tools.lib
+ - path: \**\360tools*.exe
+ - path: \**\360tools*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2010
 configuration: Release
 
 environment:
@@ -15,7 +15,7 @@ before_build:
     cmake --version
 
 build_script:
- - msbuild c:\projects\360tools\build\x86_windows\%target% /p:PlatformToolset=v100
+ - msbuild c:\projects\360tools\build\x86_windows\%target%
  
 artifacts:
  - path: cmake_build\Release\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ configuration: Release
 
 environment:
   matrix:
+   - target: 360tools_vs2010.sln
    - target: 360tools_conv_vs2010.vcxproj
    - target: 360tools_metric_vs2010.vcxproj
    - target: 360tools_conv_vs2010.vcxproj
@@ -18,4 +19,4 @@ build_script:
  - msbuild c:\projects\360tools\build\x86_windows\%target%
  
 artifacts:
- - path: cmake_build\Release\*.exe
+ - path: \**\360tools.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,15 +8,9 @@ environment:
    - target: 360tools_metric_vs2010.vcxproj
    - target: 360tools_conv_vs2010.vcxproj
 
-before_build:
-- cmd: |-
-    cd %APPVEYOR_BUILD_FOLDER%
-    mkdir cmake_build
-    cd cmake_build
-    cmake --version
-
 build_script:
  - msbuild c:\projects\360tools\build\x86_windows\%target%
  
 artifacts:
  - path: \**\360tools.exe
+ - path: \**\360tools.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
     cmake --version
 
 build_script:
- - msbuild c:\projects\360tools\build\x86_windows\%target%
+ - msbuild c:\projects\360tools\build\x86_windows\%target% /p:PlatformToolset=v100
  
 artifacts:
  - path: cmake_build\Release\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ before_build:
     mkdir cmake_build
     cd cmake_build
     cmake --version
-    cmake c:\projects\360tools\build\x86_windows
 
 build_script:
  - msbuild c:\projects\360tools\build\x86_windows\$target

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2010
+image: Visual Studio 2015
 configuration: Release
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
    - target: 360tools_vs2010.sln
    - target: 360tools_conv_vs2010.vcxproj
    - target: 360tools_metric_vs2010.vcxproj
-   - target: 360tools_conv_vs2010.vcxproj
+   - target: 360tools_lib_vs2010.vcxproj
 
 build_script:
  - msbuild c:\projects\360tools\build\x86_windows\%target%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
     cmake --version
 
 build_script:
- - msbuild c:\projects\360tools\build\x86_windows\$target
+ - msbuild c:\projects\360tools\build\x86_windows\%target%
  
 artifacts:
  - path: cmake_build\Release\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+image: Visual Studio 2017
+configuration: Release
+
+environment:
+  matrix:
+   - target: 360tools_conv_vs2010.vcxproj
+   - target: 360tools_metric_vs2010.vcxproj
+   - target: 360tools_conv_vs2010.vcxproj
+
+before_build:
+- cmd: |-
+    cd %APPVEYOR_BUILD_FOLDER%
+    mkdir cmake_build
+    cd cmake_build
+    cmake --version
+
+build_script:
+ - cmake c:\projects\360tools\build/x86_windows\%target%
+ 
+artifacts:
+ - path: cmake_build\Release\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,10 @@ before_build:
     mkdir cmake_build
     cd cmake_build
     cmake --version
+    cmake c:\projects\360tools\build\x86_windows
 
 build_script:
- - cmake c:\projects\360tools\build/x86_windows\%target%
+ - msbuild c:\projects\360tools\build\x86_windows\$target
  
 artifacts:
  - path: cmake_build\Release\*.exe


### PR DESCRIPTION
Add AppVeyor CI to 360tools. The `.vcproj` and `.sln` are build with Visual Studio and artifacts are uploaded to AppVeyor. See example here: https://ci.appveyor.com/project/EwoutH/360tools

Also adds a Build Status badge to the Readme.

Travis only needs to be activated on https://ci.appveyor.com/project/Samsung/360tools or on https://github.com/marketplace/appveyor